### PR TITLE
Allow use of any node image

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ resource "kind" "my-cluster" {
     name = "test-cluster"
 }
 ```
-To override the base image used, you can specify in addition the `base_image` like so:
+To override the base image used, you can specify in addition the `node_image` like so:
 ```
 provider "kind" {
 
@@ -49,7 +49,7 @@ provider "kind" {
 # creating a cluster with kind of the name "test-cluster" with kubernetes version v1.16.1
 resource "kind" "my-cluster" {
     name = "test-cluster"
-    base_image = "kindest/node:v1.16.1"
+    node_image = "kindest/node:v1.16.1"
 }
 ```
 1. Initialize Terraform:

--- a/README.md
+++ b/README.md
@@ -36,10 +36,20 @@ Perform the following steps to use the provider:
 provider "kind" {
 
 }
-# creating a cluster with kind of the name "test-cluster" with kubernetes version v1.15.3
+# creating a cluster with kind of the name "test-cluster" with kubernetes version v1.15.3 as is hardcoded in kind 0.5.1
 resource "kind" "my-cluster" {
     name = "test-cluster"
-    k8s_version = "v1.15.3"
+}
+```
+To override the base image used, you can specify in addition the `base_image` like so:
+```
+provider "kind" {
+
+}
+# creating a cluster with kind of the name "test-cluster" with kubernetes version v1.16.1
+resource "kind" "my-cluster" {
+    name = "test-cluster"
+    base_image = "kindest/node:v1.16.1"
 }
 ```
 1. Initialize Terraform:

--- a/before-commit.sh
+++ b/before-commit.sh
@@ -33,7 +33,7 @@ if [ "$1" == "$CI_FLAG" ]; then
 	buildEnv="env CGO_ENABLED=0"
 fi
 
-${buildEnv} go build -o bin/terraform-provider-gardener
+${buildEnv} go build -o bin/terraform-provider-kind
 
 goBuildResult=$?
 if [ ${goBuildResult} != 0 ]; then

--- a/example/main.tf
+++ b/example/main.tf
@@ -4,5 +4,4 @@ provider "kind" {
 
 resource "kind" "my-cluster" {
     name = "test-cluster"
-    k8s_version = "v1.15.3"
 }

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,6 +1,4 @@
-provider "kind" {
-    
-}
+provider "kind" {}
 
 resource "kind" "my-cluster" {
     name = "test-cluster"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tehcyx/terraform-prodiver-kind
+module github.com/kyma-incubator/terraform-prodiver-kind
 
 go 1.12
 

--- a/kind/provider.go
+++ b/kind/provider.go
@@ -16,7 +16,7 @@ func resourceKind() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceKindCreate,
 		Read:   resourceKindRead,
-		Update: resourceKindUpdate,
+		// Update: resourceKindUpdate,
 		Delete: resourceKindDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -24,11 +24,14 @@ func resourceKind() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The kind name that is given to the created cluster",
 				Required:    true,
+				ForceNew:    true,
 			},
-			"k8s_version": &schema.Schema{
+			"base_image": &schema.Schema{
 				Type:        schema.TypeString,
-				Description: `The kubernetes version that the kind will use (ex: v1.15.3) valid values are tags from https://hub.docker.com/r/kindest/node/tags`,
-				Required:    true,
+				Description: `The base_image that kind will use (ex: kindest/node:v1.15.3)`,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
 			},
 			"k8s_kubeconfig_path": &schema.Schema{
 				Type:        schema.TypeString,

--- a/kind/provider.go
+++ b/kind/provider.go
@@ -26,9 +26,9 @@ func resourceKind() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
-			"base_image": &schema.Schema{
+			"node_image": &schema.Schema{
 				Type:        schema.TypeString,
-				Description: `The base_image that kind will use (ex: kindest/node:v1.15.3)`,
+				Description: `The node_image that kind will use (ex: kindest/node:v1.15.3)`,
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,

--- a/kind/resource_kind.go
+++ b/kind/resource_kind.go
@@ -18,7 +18,7 @@ func resourceKindCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Println("Creating local Kubernetes cluster...")
 	name := d.Get("name").(string)
 	ctx := cluster.NewContext(name)
-	baseImage := d.Get("base_image").(string)
+	baseImage := d.Get("node_image").(string)
 
 	log.Println("=================== Creating Kind Cluster ==================")
 	var opts []create.ClusterOption
@@ -27,7 +27,7 @@ func resourceKindCreate(d *schema.ResourceData, meta interface{}) error {
 		opts = append(opts, create.WithNodeImage(baseImage))
 		log.Printf("Using defined base image: %s\n", baseImage)
 	} else {
-		d.Set("base_image", kindDefaults.Image) // set image to k/kind default image.
+		d.Set("node_image", kindDefaults.Image) // set image to k/kind default image.
 		baseImage = kindDefaults.Image
 	}
 
@@ -64,8 +64,8 @@ func resourceKindUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Println("")
 	d.Partial(true)
 
-	if d.HasChange("base_image") {
-		d.SetPartial("base_image")
+	if d.HasChange("node_image") {
+		d.SetPartial("node_image")
 	}
 	if d.HasChange("name") {
 		d.SetPartial("name")

--- a/kind/resource_kind.go
+++ b/kind/resource_kind.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	kindDefaults "sigs.k8s.io/kind/pkg/apis/config/defaults"
 	cluster "sigs.k8s.io/kind/pkg/cluster"
 	create "sigs.k8s.io/kind/pkg/cluster/create"
 )
@@ -17,18 +18,25 @@ func resourceKindCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Println("Creating local Kubernetes cluster...")
 	name := d.Get("name").(string)
 	ctx := cluster.NewContext(name)
-	kubernetesVersion := d.Get("k8s_version").(string)
+	baseImage := d.Get("base_image").(string)
 
 	log.Println("=================== Creating Kind Cluster ==================")
-	k8Setup := create.SetupKubernetes(true)
-	k8sVersion := create.WithNodeImage(fmt.Sprintf("kindest/node:%s", kubernetesVersion))
+	var opts []create.ClusterOption
+	opts = append(opts, create.SetupKubernetes(true))
+	if baseImage != "" {
+		opts = append(opts, create.WithNodeImage(baseImage))
+		log.Printf("Using defined base image: %s\n", baseImage)
+	} else {
+		d.Set("base_image", kindDefaults.Image) // set image to k/kind default image.
+		baseImage = kindDefaults.Image
+	}
 
-	err := ctx.Create(k8Setup, k8sVersion)
+	err := ctx.Create(opts...)
 	if err != nil {
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("%s-%s", name, kubernetesVersion))
+	d.SetId(fmt.Sprintf("%s-%s", name, baseImage))
 	return resourceKindRead(d, meta)
 }
 
@@ -53,8 +61,18 @@ func resourceKindRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceKindUpdate(d *schema.ResourceData, meta interface{}) error {
-	log.Println("update not yet implemented")
-	return nil
+	log.Println("")
+	d.Partial(true)
+
+	if d.HasChange("base_image") {
+		d.SetPartial("base_image")
+	}
+	if d.HasChange("name") {
+		d.SetPartial("name")
+	}
+
+	d.Partial(false)
+	return resourceKindRead(d, meta)
 }
 
 func resourceKindDelete(d *schema.ResourceData, meta interface{}) error {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/tehcyx/terraform-prodiver-kind/kind"
+	"github.com/kyma-incubator/terraform-prodiver-kind/kind"
 )
 
 func main() {


### PR DESCRIPTION
- Allows usage of different than standard node images
- Fixes an issue were a wrongly named binary would be output
- Fixes an issue where the wrong go.mod project path was set