### PR TITLE
Parse client config file into properties

### DIFF
--- a/kind/provider.go
+++ b/kind/provider.go
@@ -38,6 +38,26 @@ func resourceKind() *schema.Resource {
 				Description: `Kubeconfig path set after the the cluster is created.`,
 				Computed:    true,
 			},
+			"client_certificate": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: `Client certificate for authenticating to cluster.`,
+				Computed:    true,
+			},
+			"client_key": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: `Client key for authenticating to cluster.`,
+				Computed:    true,
+			},
+			"cluster_ca_certificate": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: `Client verifies the server certificate with this CA cert.`,
+				Computed:    true,
+			},
+			"endpoint": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: `Kubernetes APIServer endpoint.`,
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/kind/resource_kind.go
+++ b/kind/resource_kind.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	clientcmd "k8s.io/client-go/tools/clientcmd"
 	kindDefaults "sigs.k8s.io/kind/pkg/apis/config/defaults"
 	cluster "sigs.k8s.io/kind/pkg/cluster"
 	create "sigs.k8s.io/kind/pkg/cluster/create"
@@ -54,6 +55,17 @@ func resourceKindRead(d *schema.ResourceData, meta interface{}) error {
 
 	k8sKubeconfigPath := ctx.KubeConfigPath()
 	d.Set("k8s_kubeconfig_path", k8sKubeconfigPath)
+
+	// use the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", k8sKubeconfigPath)
+	if err != nil {
+		return err
+	}
+
+	d.Set("client_certificate", string(config.CertData))
+	d.Set("client_key", string(config.KeyData))
+	d.Set("cluster_ca_certificate", string(config.CAData))
+	d.Set("endpoint", string(config.Host))
 
 	d.Set("completed", true)
 


### PR DESCRIPTION
# ADDED
Properties parsed from kubeconfig file used for authenticating to API server endpoint

 - client_certificate
 - client_key
 - cluster_ca_certificate
 - endpoint