### PR TITLE
Let the kubeconfig attribute return the external kubeconfig fix #20

### DIFF
--- a/kind/resource_cluster.go
+++ b/kind/resource_cluster.go
@@ -128,7 +128,7 @@ func resourceKindClusterRead(d *schema.ResourceData, meta interface{}) error {
 	id := d.Id()
 	log.Printf("ID: %s\n", id)
 
-	kconfig, err := provider.KubeConfig(name, true)
+	kconfig, err := provider.KubeConfig(name, false)
 	if err != nil {
 		d.SetId("")
 		return err


### PR DESCRIPTION
KinD has an internal and an external kubeconfig. With this commit,
the kubeconfig returned as an attribute of the kind_cluster resource
will have the external kubeconfig, the same as written to the file
using provider.ExportKubeConfig, which always returns the external
config.