### PR TITLE
Add support for containerd config patches

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -48,6 +48,25 @@ resource "kind_cluster" "default" {
 }
 ```
 
+
+```hcl
+provider "kind" {}
+
+# Create a cluster with patches applied to the containerd config
+resource "kind_cluster" "default" {
+    name = "test-cluster"
+    node_image = "kindest/node:v1.16.1"
+    kind_config = {
+        containerd_config_patches = [
+            <<-TOML
+            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+                endpoint = ["http://kind-registry:5000"]
+            TOML
+        ]
+    }
+}
+```
+
 ## Argument Reference
 
 * `name` - (Required) The kind name that is given to the created cluster.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/imdario/mergo v0.3.9 // indirect
+	github.com/pelletier/go-toml v1.8.0
 	github.com/zclconf/go-cty v1.5.1 // indirect
 	github.com/zclconf/go-cty-yaml v1.0.2 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect

--- a/kind/resource_cluster_test.go
+++ b/kind/resource_cluster_test.go
@@ -252,6 +252,45 @@ func TestAccClusterConfigNodes(t *testing.T) {
 	})
 }
 
+func TestAccClusterContainerdPatches(t *testing.T) {
+	resourceName := "kind_cluster.test"
+	clusterName := acctest.RandomWithPrefix("tf-acc-containerd-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKindClusterResourceDestroy(clusterName),
+		Steps: []resource.TestStep{
+			{
+				Config: testSingleContainerdConfigPatch(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterCreate(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckNoResourceAttr(resourceName, "node_image"),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_ready", "true"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.0.kind", "Cluster"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.0.api_version", "kind.x-k8s.io/v1alpha4"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.0.containerd_config_patches.#", "1"),
+				),
+			},
+			{
+				Config: testTwoContainerdConfigPatches(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterCreate(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckNoResourceAttr(resourceName, "node_image"),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_ready", "true"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.0.kind", "Cluster"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.0.api_version", "kind.x-k8s.io/v1alpha4"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.0.containerd_config_patches.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 // testAccCheckKindClusterResourceDestroy verifies the kind cluster
 // has been destroyed
 func testAccCheckKindClusterResourceDestroy(clusterName string) resource.TestCheckFunc {
@@ -507,4 +546,47 @@ resource "kind_cluster" "test" {
   }
 }
 `, name, nodeImage)
+}
+
+func testSingleContainerdConfigPatch(name string) string {
+	return fmt.Sprintf(`
+resource "kind_cluster" "test" {
+  name = "%s"
+  wait_for_ready = true
+  kind_config {
+	kind = "Cluster"
+	api_version = "kind.x-k8s.io/v1alpha4"
+	containerd_config_patches = [
+		<<-TOML
+		[plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+			endpoint = ["http://kind-registry:5000"]
+		TOML
+	]
+  }
+}
+`, name)
+}
+
+func testTwoContainerdConfigPatches(name string) string {
+	return fmt.Sprintf(`
+resource "kind_cluster" "test" {
+  name = "%s"
+  wait_for_ready = true
+  kind_config {
+	kind = "Cluster"
+	api_version = "kind.x-k8s.io/v1alpha4"
+	containerd_config_patches = [
+		<<-TOML
+		[plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+			endpoint = ["http://kind-registry:5000"]
+		TOML
+		,
+		<<-TOML
+		[plugins."io.containerd.grpc.v1.cri"]
+			sandbox_image = "k8s.gcr.io/pause:3.2"
+		TOML
+	]
+  }
+}
+`, name)
 }

--- a/kind/schema_kind_config.go
+++ b/kind/schema_kind_config.go
@@ -43,9 +43,13 @@ func kindConfigFields() map[string]*schema.Schema {
 			Elem: &schema.Schema{
 				Type:         schema.TypeString,
 				ValidateFunc: stringIsValidToml,
-				StateFunc: func(tomlString interface{}) string {
-					normalizeToml, _ := normalizeToml(tomlString)
-					return normalizeToml
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// We can ignore these errors for two reasons:
+					// 1. normalizeToml returns the input in case of error
+					// 2. the ValidateFunc should ensure an early exit
+					normalizedOld, _ := normalizeToml(old)
+					normalizedNew, _ := normalizeToml(new)
+					return normalizedOld == normalizedNew
 				},
 			},
 		},

--- a/kind/schema_kind_config.go
+++ b/kind/schema_kind_config.go
@@ -37,6 +37,13 @@ func kindConfigFields() map[string]*schema.Schema {
 				Schema: kindConfigNetworkingFields(),
 			},
 		},
+		"containerd_config_patches": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 	}
 	return forceNewAll(s)
 }

--- a/kind/schema_kind_config.go
+++ b/kind/schema_kind_config.go
@@ -41,7 +41,12 @@ func kindConfigFields() map[string]*schema.Schema {
 			Type:     schema.TypeList,
 			Optional: true,
 			Elem: &schema.Schema{
-				Type: schema.TypeString,
+				Type:         schema.TypeString,
+				ValidateFunc: stringIsValidToml,
+				StateFunc: func(tomlString interface{}) string {
+					normalizeToml, _ := normalizeToml(tomlString)
+					return normalizeToml
+				},
 			},
 		},
 	}

--- a/kind/structure.go
+++ b/kind/structure.go
@@ -1,0 +1,16 @@
+package kind
+
+import "github.com/pelletier/go-toml"
+
+func normalizeToml(tomlString interface{}) (string, error) {
+	if tomlString == nil || tomlString.(string) == "" {
+		return "", nil
+	}
+
+	s := tomlString.(string)
+	tree, err := toml.Load(s)
+	if err != nil {
+		return s, err
+	}
+	return tree.ToTomlString()
+}

--- a/kind/structure_kind_config.go
+++ b/kind/structure_kind_config.go
@@ -28,6 +28,14 @@ func flattenKindConfig(d map[string]interface{}) *v1alpha4.Cluster {
 		}
 	}
 
+	containerdConfigPatches := mapKeyIfExists(d, "containerd_config_patches")
+	if containerdConfigPatches != nil {
+		for _, p := range containerdConfigPatches.([]interface{}) {
+			patch := p.(string)
+			obj.ContainerdConfigPatches = append(obj.ContainerdConfigPatches, patch)
+		}
+	}
+
 	return obj
 }
 

--- a/kind/structure_test.go
+++ b/kind/structure_test.go
@@ -1,0 +1,66 @@
+package kind
+
+import (
+	"testing"
+)
+
+func TestNormalizeTomlString(t *testing.T) {
+	cases := []struct {
+		Name            string
+		Input           string
+		ExpectedOutput  string
+		ExpectUnchanged bool
+		ExpectError     bool
+	}{
+		{
+			Name: "WellFormattedIsReturnedAsIs",
+			Input: `name = "Test"
+
+[section]
+  key = "value"
+`,
+			ExpectUnchanged: true,
+		},
+		{
+			Name: "MalformedInputResultsInErrorAndReturnsInput",
+			Input: `fruit = []
+[[fruit]]
+`,
+			ExpectUnchanged: true,
+			ExpectError:     true,
+		},
+		{
+			Name: "UnformattedInputIsFormatted",
+			Input: `name = "test"
+[fruit.apple]
+[animal]
+[fruit]
+`,
+			ExpectedOutput: `name = "test"
+
+[animal]
+
+[fruit]
+
+  [fruit.apple]
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			output, err := normalizeToml(tc.Input)
+			if err != nil {
+				if !tc.ExpectError {
+					t.Error("received error but expected no errors for case", err)
+				}
+			}
+			if tc.ExpectUnchanged && output != tc.Input {
+				t.Errorf("received:\n---\n%s\n---\n but expected input \n---\n%s\n---\n to be unchanged", output, tc.Input)
+			}
+			if !tc.ExpectUnchanged && output != tc.ExpectedOutput {
+				t.Errorf("received \n---\n%s\n---\n but expected \n---\n%s\n---\n", output, tc.ExpectedOutput)
+			}
+		})
+	}
+}

--- a/kind/validation.go
+++ b/kind/validation.go
@@ -1,0 +1,18 @@
+package kind
+
+import (
+	"fmt"
+)
+
+func stringIsValidToml(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return warnings, errors
+	}
+	_, err := normalizeToml(v)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%s is not valid toml: %s", k, err))
+	}
+	return warnings, errors
+}

--- a/kind/validation_test.go
+++ b/kind/validation_test.go
@@ -1,0 +1,52 @@
+package kind
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStringIsValidToml(t *testing.T) {
+	cases := []struct {
+		Name             string
+		Value            interface{}
+		Key              string
+		ExpectedErrors   int
+		ExpectedWarnings int
+	}{
+		{
+			Name:           "PassingNonStringIsAnError",
+			Value:          struct{}{},
+			ExpectedErrors: 1,
+		},
+		{
+			Name:  "ValidTomlIsValid",
+			Value: "the_answer_to_everything = 42",
+		},
+		{
+			Name:           "NilIsInvalid",
+			Value:          nil,
+			ExpectedErrors: 1,
+		},
+		{
+			Name:  "EmptyStringIsValid",
+			Value: "",
+		},
+		{
+			Name:           "InvalidTomlIsInvalid",
+			Value:          strings.Join([]string{"fruits = []", "[[fruits]]"}, "\n"),
+			ExpectedErrors: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			warnings, errors := stringIsValidToml(tc.Value, tc.Key)
+			if len(warnings) != tc.ExpectedWarnings {
+				t.Errorf("expected %d warnings but got len(%v) = %d", tc.ExpectedWarnings, warnings, len(warnings))
+			}
+			if len(errors) != tc.ExpectedErrors {
+				t.Errorf("expected %d warnings but got len(%v) = %d", tc.ExpectedErrors, errors, len(errors))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Heya. With the move to HCL kind_config, we lost the ability to apply containerd config patches. We use this to make working with a local registry easier. This PR aims to address this gap by providing support for strategic merge based containerd patches.