### PR TITLE
allow to pass kubeconfig

### DIFF
--- a/kind/resource_cluster_test.go
+++ b/kind/resource_cluster_test.go
@@ -46,6 +46,17 @@ func TestAccCluster(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccBasicClusterConfigWithKubeconfigPath(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterCreate(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "kubeconfig_path", "/tmp/kind-provider-test/new_file"),
+					resource.TestCheckNoResourceAttr(resourceName, "node_image"),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_ready", "false"),
+					resource.TestCheckNoResourceAttr(resourceName, "kind_config"),
+				),
+			},
+			{
 				Config: testAccBasicWaitForReadyClusterConfig(clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterCreate(resourceName),
@@ -356,6 +367,16 @@ func testAccBasicClusterConfig(name string) string {
 	return fmt.Sprintf(`
 resource "kind_cluster" "test" {
   name = "%s"
+}
+`, name)
+}
+
+func testAccBasicClusterConfigWithKubeconfigPath(name string) string {
+
+	return fmt.Sprintf(`
+resource "kind_cluster" "test" {
+  name = "%s"
+  kubeconfig_path = "/tmp/kind-provider-test/new_file"
 }
 `, name)
 }


### PR DESCRIPTION
This PR enables passing of kubeconfig_path in the terraform file. Feature from #34 

Use like this:
```
provider "kind" {}

resource "kind_cluster" "default" {
    name = "test-cluster"
    kubeconfig_path = "/tmp/kind-provider-test/new_file"
}
```

Validation is not done via this provider. E.g. if path is not a file, kind itself will fail that it can't write the config to a file and the user has to take care of this themselves.