### PR TITLE
Add missing docs for computed attributes

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -73,3 +73,15 @@ resource "kind_cluster" "default" {
 * `node_image` - (Optional) The node_image that kind will use (ex: kindest/node:v1.15.3).
 * `wait_for_ready` - (Optional) Defines wether or not the provider will wait for the control plane to be ready. Defaults to false.
 * `kind_config` - (Optional) The kind_config that kind will use.
+* `kubeconfig_path` - kubeconfig path set after the the cluster is created or by the user to override defaults.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `kubeconfig` - The kubeconfig for the cluster after it is created
+* `client_certificate` - Client certificate for authenticating to cluster.
+* `client_key` - Client key for authenticating to cluster.
+* `cluster_ca_certificate` - Client verifies the server certificate with this CA cert.
+* `endpoint` - Kubernetes APIServer endpoint.


### PR DESCRIPTION
Was trying to use this for testing and found some things missing in the docs. This PR adds the docs for the computed attributes on the cluster.